### PR TITLE
Add basic test setup and rename base to instance as main API endpoint

### DIFF
--- a/encore.gemspec
+++ b/encore.gemspec
@@ -17,5 +17,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split($/)
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'activemodel', '>= 3.0.0'
+  spec.add_dependency 'activerecord', '>= 3.0.0'
+  spec.add_dependency 'active_model_serializers', '~> 0.8.0'
+  spec.add_dependency 'kaminari', '~> 0.15.1'
+
   spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'rake', '~> 10.3'
+  spec.add_development_dependency 'rspec', '3.0.0beta2'
+  spec.add_development_dependency 'sqlite3', '>= 1.3.8', '< 1.4'
 end

--- a/lib/encore.rb
+++ b/lib/encore.rb
@@ -1,7 +1,9 @@
-require 'encore/persister/base'
 require 'encore/serializer/base'
+require 'encore/serializer/instance'
+require 'encore/persister/instance'
 
 require 'encore/version'
+require 'encore/config'
 
 module Encore
 end

--- a/lib/encore/config.rb
+++ b/lib/encore/config.rb
@@ -1,0 +1,1 @@
+ActiveModel::Serializer.root = false

--- a/lib/encore/persister/instance.rb
+++ b/lib/encore/persister/instance.rb
@@ -5,7 +5,7 @@ require 'encore/persister/links_parser'
 
 module Encore
   module Persister
-    class Base
+    class Instance
       include LinksParser
       include ErrorsParser
 

--- a/lib/encore/serializer/base.rb
+++ b/lib/encore/serializer/base.rb
@@ -1,78 +1,70 @@
-require 'encore/serializer/inclusion'
-require 'encore/serializer/eager_loading'
-require 'encore/serializer/linked_loading'
-require 'encore/serializer/linked_serialized'
-require 'encore/serializer/links_info'
-require 'encore/serializer/main_paging'
-require 'encore/serializer/main_serialized'
-require 'encore/serializer/paging'
-
 module Encore
   module Serializer
-    class Base
-      include Inclusion
-      include EagerLoading
-      include MainSerialized
-      include Paging
-      include MainPaging
-      include LinkedLoading
-      include LinkedSerialized
-      include LinksInfo
-
-      def initialize(collection, include: '', page: 1, per_page: Kaminari.config.default_per_page, no_paging: false)
-        @collection = collection
-        @includes = parsed_includes(include)
-        @serializers = [serializer]
-        @no_paging = no_paging
-
-        unless @no_paging
-          @page = page.to_i
-          @per_page = parse_per_page(per_page)
-        end
+    class Base < ::ActiveModel::Serializer
+      def id
+        object.id.to_s
       end
 
-      def as_json(*_)
-        # Prepare main collection
-        unless @no_paging
-          @collection = paginated_collection(@collection, @page, @per_page)
+      def links
+        output = {}
+
+        object.reflections.each do |_, reflection|
+          if reflection.belongs_to?
+            output.merge! reflection.name => belongs_to(reflection)
+          else
+            if add_reflection?(reflection)
+              if link = reflection_association(reflection)
+                output.merge! reflection.name => link
+              end
+            end
+          end
         end
-
-        @collection = add_eager_loading(@collection, @includes)
-
-        # Fetch linked ids
-        linked_ids = add_linked_sets(@collection, @includes)
-
-        # Build final output
-        output = add_main_serialized(@collection)
-        output.merge! links: add_links_info
-        output.merge! linked: add_linked_serialized(linked_ids)
-
-        if @no_paging
-          meta = {}
-        else
-          meta = add_main_pagination(@collection)
-        end
-
-        output.merge! meta: meta
 
         output
       end
 
+      def self.can_include
+        []
+      end
+
+      def self.always_include
+        []
+      end
+
+      def self.can_access
+        can_include
+      end
+
+      def self.root_key
+        model_class.name.pluralize.underscore.to_sym
+      end
+
     private
 
-      def reflections
-        @reflections ||= @collection.klass.reflections
+      def add_reflection?(reflection)
+        self.class.can_include.include?(reflection.name) || self.class.always_include.include?(reflection.name)
       end
 
-      def serializer
-        @serializer ||= fetch_serializer(@collection.klass)
+      def belongs_to(reflection)
+        object.send(reflection.foreign_key).try(:to_s) if object.respond_to?(reflection.foreign_key)
       end
 
-      def fetch_serializer(model)
-        default_serializer = (model.name.gsub('::', '') + 'Serializer')
-        model.active_model_serializer || default_serializer.constantize
-      rescue NameError
-        raise NameError, "can’t find serializer for #{model.name}, try creating #{default_serializer}"
+      def one(reflection)
+        object.send(reflection.name).try(:id).try(:to_s)
+      end
+
+      def many(reflection)
+        object.send("#{reflection.name.to_s.singularize}_ids").map(&:to_s) if object.send(reflection.name).loaded?
+      end
+
+      def reflection_association(reflection)
+        case reflection.macro
+          when :belongs_to then belongs_to(reflection)
+          when :has_one then one(reflection)
+          when :has_many then many(reflection)
+          else
+            nil
+        end
       end
     end
   end

--- a/lib/encore/serializer/instance.rb
+++ b/lib/encore/serializer/instance.rb
@@ -1,0 +1,79 @@
+require 'encore/serializer/inclusion'
+require 'encore/serializer/eager_loading'
+require 'encore/serializer/linked_loading'
+require 'encore/serializer/linked_serialized'
+require 'encore/serializer/links_info'
+require 'encore/serializer/main_paging'
+require 'encore/serializer/main_serialized'
+require 'encore/serializer/paging'
+
+module Encore
+  module Serializer
+    class Instance
+      include Inclusion
+      include EagerLoading
+      include MainSerialized
+      include Paging
+      include MainPaging
+      include LinkedLoading
+      include LinkedSerialized
+      include LinksInfo
+
+      def initialize(collection, include: '', page: 1, per_page: Kaminari.config.default_per_page, no_paging: false)
+        @collection = collection
+        @includes = parsed_includes(include)
+        @serializers = [serializer]
+        @no_paging = no_paging
+
+        unless @no_paging
+          @page = page.to_i
+          @per_page = parse_per_page(per_page)
+        end
+      end
+
+      def as_json(*_)
+        # Prepare main collection
+        unless @no_paging
+          @collection = paginated_collection(@collection, @page, @per_page)
+        end
+
+        @collection = add_eager_loading(@collection, @includes)
+
+        # Fetch linked ids
+        linked_ids = add_linked_sets(@collection, @includes)
+
+        # Build final output
+        output = add_main_serialized(@collection)
+        output.merge! links: add_links_info
+        output.merge! linked: add_linked_serialized(linked_ids)
+
+        if @no_paging
+          meta = {}
+        else
+          meta = add_main_pagination(@collection)
+        end
+
+        output.merge! meta: meta
+
+        output
+      end
+
+    private
+
+      def reflections
+        @reflections ||= @collection.klass.reflections
+      end
+
+      def serializer
+        @serializer ||= fetch_serializer(@collection.klass)
+      end
+
+      def fetch_serializer(model)
+        default_serializer = (model.name.gsub('::', '') + 'Serializer')
+        model.active_model_serializer || default_serializer.constantize
+      rescue NameError
+        raise NameError, "can’t find serializer for #{model.name}, try creating #{default_serializer}"
+      end
+    end
+  end
+end

--- a/spec/encore/serializer/main_paging_spec.rb
+++ b/spec/encore/serializer/main_paging_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe Encore::Serializer do
+  let(:serializer) { Encore::Serializer::Instance }
+  let(:objects) { User.all }
+  let(:serialized) { serializer.new(objects, page: page).as_json }
+
+  let(:run_migrations!) do
+    run_migration do
+      create_table(:users, force: true) do |t|
+        t.string :name, default: nil
+        t.string :discarded_attribute, default: nil
+      end
+    end
+  end
+
+  let(:spawn_objects!) do
+    spawn_model('User')
+    spawn_serializer('UserSerializer') do
+      attributes :name
+    end
+  end
+
+  let(:create_records!) do
+    User.create name: 'Allan'
+    User.create name: 'Doe'
+    User.create name: 'Ding'
+    User.create name: 'Bob'
+  end
+
+  let(:paging_config) do
+    double(
+      'Kaminari',
+      page_method_name: 'page',
+      default_per_page: 1,
+      max_per_page: 1,
+      max_pages: 10
+    )
+  end
+
+  before do
+    expect(Kaminari).to receive(:config).and_return(paging_config).at_least(:once)
+    run_migrations!
+    spawn_objects!
+    create_records!
+  end
+
+  context 'page 1' do
+    let(:page) { 1 }
+
+    it { expect(serialized[:meta][:users][:page]).to eq(1) }
+    it { expect(serialized[:meta][:users][:count]).to eq(4) }
+    it { expect(serialized[:meta][:users][:page_count]).to eq(4) }
+    it { expect(serialized[:meta][:users][:next_page]).to eq(2) }
+  end
+
+  context 'page 2' do
+    let(:page) { 2 }
+
+    it { expect(serialized[:meta][:users][:page]).to eq(2) }
+    it { expect(serialized[:meta][:users][:count]).to eq(4) }
+    it { expect(serialized[:meta][:users][:page_count]).to eq(4) }
+    it { expect(serialized[:meta][:users][:previous_page]).to eq(1) }
+    it { expect(serialized[:meta][:users][:next_page]).to eq(3) }
+  end
+end

--- a/spec/encore/serializer/main_serialized_spec.rb
+++ b/spec/encore/serializer/main_serialized_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Encore::Serializer do
+  let(:serializer) { Encore::Serializer::Instance }
+  let(:objects) { User.all }
+  let(:serialized) { serializer.new(objects).as_json }
+
+  let(:run_migrations!) do
+    run_migration do
+      create_table(:users, force: true) do |t|
+        t.string :name, default: nil
+        t.string :discarded_attribute, default: nil
+      end
+    end
+  end
+
+  let(:spawn_objects!) do
+    spawn_model('User')
+    spawn_serializer('UserSerializer') do
+      attributes :name
+    end
+  end
+
+  let(:create_records!) do
+    User.create name: 'Allan', discarded_attribute: 'THIS IS MY PASSWORD'
+    User.create name: 'Doe'
+  end
+
+  before do
+    run_migrations!
+    spawn_objects!
+    create_records!
+  end
+
+  it { expect(serialized[:users].count).to eq(2) }
+  it { expect(serialized[:users]).to eq([{ name: 'Allan' }, { name: 'Doe' }]) }
+end

--- a/spec/encore_spec.rb
+++ b/spec/encore_spec.rb
@@ -1,0 +1,4 @@
+require 'spec_helper'
+
+describe Encore do
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,27 @@
+$:.unshift File.expand_path('../lib', __FILE__)
+
+require 'rspec'
+require 'sqlite3'
+
+require 'kaminari'
+require 'active_record'
+require 'active_model'
+require 'active_model_serializers'
+
+Kaminari::Hooks.init
+
+require 'encore'
+
+# Require our macros and extensions
+Dir[File.expand_path('../../spec/support/macros/**/*.rb', __FILE__)].map(&method(:require))
+
+RSpec.configure do |config|
+  # Include our macros
+  config.include DatabaseMacros
+  config.include ModelMacros
+
+  config.before :each do
+    adapter = ENV['DB_ADAPTER'] || 'sqlite3'
+    setup_database(adapter: adapter, database: 'encore_test')
+  end
+end

--- a/spec/support/macros/database/database_adapter.rb
+++ b/spec/support/macros/database/database_adapter.rb
@@ -1,0 +1,9 @@
+class DatabaseAdapter
+  def initialize(opts = {})
+    @database = opts[:database]
+  end
+
+  def establish_connection!
+    ActiveRecord::Base.establish_connection(database_configuration)
+  end
+end

--- a/spec/support/macros/database/sqlite3_adapter.rb
+++ b/spec/support/macros/database/sqlite3_adapter.rb
@@ -1,0 +1,14 @@
+require_relative 'database_adapter'
+
+class Sqlite3Adapter < DatabaseAdapter
+  def database_configuration
+    {
+      adapter: 'sqlite3',
+      database: ':memory:'
+    }
+  end
+
+  def reset_database!
+    ActiveRecord::Base.connection.execute("select 'drop table ' || name || ';' from sqlite_master where type = 'table';")
+  end
+end

--- a/spec/support/macros/database_macros.rb
+++ b/spec/support/macros/database_macros.rb
@@ -1,0 +1,22 @@
+module DatabaseMacros
+  # Run migrations in the test database
+  def run_migration(&block)
+    # Create a new migration class
+    klass = Class.new(ActiveRecord::Migration)
+
+    # Create a new `up` that executes the argument
+    klass.send(:define_method, :up) { self.instance_exec(&block) }
+
+    # Create a new instance of it and execute its `up` method
+    klass.new.up
+  end
+
+  def setup_database(opts = {})
+    adapter = "#{opts[:adapter].capitalize}Adapter".constantize.new(database: opts[:database])
+    adapter.establish_connection!
+    adapter.reset_database!
+
+    # Silence everything
+    ActiveRecord::Base.logger = ActiveRecord::Migration.verbose = false
+  end
+end

--- a/spec/support/macros/model_macros.rb
+++ b/spec/support/macros/model_macros.rb
@@ -1,0 +1,24 @@
+module ModelMacros
+  # Create a new ActiveRecord model
+  def spawn_model(klass_name, options = {}, &block)
+    spawn_object klass_name, ActiveRecord::Base do
+      instance_exec(&block) if block
+    end
+  end
+
+  # Create a new Encore::Serializer object
+  def spawn_serializer(klass_name, options = {}, &block)
+    spawn_object klass_name, Encore::Serializer::Base do
+      instance_exec(&block) if block
+    end
+  end
+
+  protected
+
+  # Create a new model class
+  def spawn_object(klass_name, parent_klass, &block)
+    Object.instance_eval { remove_const klass_name } if Object.const_defined?(klass_name)
+    Object.const_set(klass_name, Class.new(parent_klass))
+    Object.const_get(klass_name).class_eval(&block) if block_given?
+  end
+end


### PR DESCRIPTION
Test test test!

`Serializer::Base` can now be used by all the application serializer. Like `ActiveRecord::Base` for application models.
