### PR TITLE
Require active_model_serializers in Encore::Serializer::Base

### DIFF
--- a/lib/encore.rb
+++ b/lib/encore.rb
@@ -1,4 +1,7 @@
 require 'active_model_serializers'
+require 'active_record'
+require 'active_support'
+require 'kaminari'
 
 require 'encore/version'
 require 'encore/config'


### PR DESCRIPTION
Once included in a Rails app, I had the following error:

```
.../encore/serializer/base.rb:3:in `<module:Serializer>': uninitialized constant ActiveModel::Serializer (NameError)
```
