### PR TITLE
Move Kaminari::Hooks.init away from spec_helper

### DIFF
--- a/lib/encore/config.rb
+++ b/lib/encore/config.rb
@@ -1,1 +1,2 @@
 ActiveModel::Serializer.root = false
+Kaminari::Hooks.init

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,13 +3,6 @@ $LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
 require 'rspec'
 require 'sqlite3'
 
-require 'kaminari'
-require 'active_record'
-require 'active_model'
-require 'active_model_serializers'
-
-Kaminari::Hooks.init
-
 require 'encore'
 
 # Require our macros and extensions


### PR DESCRIPTION
No need to require Encore’s dependencies in `spec_helper.rb` as we already require them in `encore.rb`.
