### PR TITLE
Add can_access documentation for Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ This will result in the following JSON output:
     }
   ],
   "links": {
-    comments.author: {
-      href: "/authors?ids={author.id}",
-      type: "user"
+    "comments.author": {
+      "href": "/authors?ids={author.id}",
+      "type": "user"
     }
   },
   "linked": {


### PR DESCRIPTION
Add `can_access` documentation to restrict exposition of an API endpoint.
