### PR TITLE
Remove I18n warning in tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,12 @@ RSpec.configure do |config|
   config.include ModelMacros
 
   config.before :each do
+    # Setup the database
     setup_database(adapter: 'sqlite3', database: 'encore_test')
+  end
+
+  config.before :suite do
+    # Enforce available locales (otherwise generating error messages throws a warning)
+    I18n.enforce_available_locales = true
   end
 end


### PR DESCRIPTION
Generating error messages relies on `I18n`.

And since Rails 4.0, we get a nice warning message when we don’t explicitly set `I18n.enforce_available_locales = true`.
