### PR TITLE
Remove warning when including Kaminari

### DIFF
--- a/lib/encore.rb
+++ b/lib/encore.rb
@@ -3,7 +3,13 @@ require 'encore/version'
 require 'active_model_serializers'
 require 'active_record'
 require 'active_support'
+
+# This is a dirty hack to fix dirty code
+# https://github.com/amatsuda/kaminari/blob/7b049067b143212a172d5bb472184eac23121f34/lib/kaminari.rb#L11-L25
+oldstderr = $stderr.dup
+$stderr = StringIO.new
 require 'kaminari'
+$stderr = oldstderr
 
 require 'encore/config'
 


### PR DESCRIPTION
##### Before

``` bash
$ rake spec
warning: no framework detected.

Your Gemfile might not be configured properly.
---- e.g. ----
Rails:
    gem 'kaminari'

Sinatra/Padrino:
    gem 'kaminari', :require => 'kaminari/sinatra'

Grape:
    gem 'kaminari', :require => 'kaminari/grape'

.........................................................

Finished in 0.82203 seconds
57 examples, 0 failures
```
##### After

``` bash
$ rake spec
.........................................................

Finished in 0.85314 seconds
57 examples, 0 failures
```
