### PR TITLE
Update documentation to be compliant with latest development

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Requesting `GET /posts?include=comments` will result in the following JSON outpu
   }
 ```
 
-If you want the `comments` the **always** be included when you request a `post`, update the `PostSerializer` this way:
+If you want the `comments` to **always** be included when you request a `post`, update the `PostSerializer` this way:
 
 ```ruby
 class PostSerializer < Encore::Serializer::Base


### PR DESCRIPTION
The documentation haven't been update when we removed the top-level `links`. I've also rewrite the scenario to include examples of `has_many` and `belongs_to` relationships.
