### PR TITLE
Always include links attribute in serializers

### DIFF
--- a/lib/encore/serializer/base.rb
+++ b/lib/encore/serializer/base.rb
@@ -3,6 +3,8 @@ require 'encore/serializer/links_reflection_includer'
 module Encore
   module Serializer
     class Base < ::ActiveModel::Serializer
+      attributes :links
+
       def id
         object.id.to_s
       end

--- a/spec/encore/serializer/linked/always_include_resources_spec.rb
+++ b/spec/encore/serializer/linked/always_include_resources_spec.rb
@@ -64,7 +64,7 @@ describe Encore::Serializer do
       end
     end
 
-    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name }, { name: project2.name }]) }
+    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name, links: {} }, { name: project2.name, links: {} }]) }
   end
 
   context 'with and no include' do
@@ -80,6 +80,6 @@ describe Encore::Serializer do
       end
     end
 
-    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name }, { name: project2.name }]) }
+    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name, links: {} }, { name: project2.name, links: {} }]) }
   end
 end

--- a/spec/encore/serializer/linked/can_include_resources_spec.rb
+++ b/spec/encore/serializer/linked/can_include_resources_spec.rb
@@ -64,6 +64,6 @@ describe Encore::Serializer do
       end
     end
 
-    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name }, { name: project2.name }]) }
+    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name, links: {} }, { name: project2.name, links: {} }]) }
   end
 end

--- a/spec/encore/serializer/linked/linked_resources_spec.rb
+++ b/spec/encore/serializer/linked/linked_resources_spec.rb
@@ -62,7 +62,7 @@ describe Encore::Serializer do
 
     let(:include) { 'project' }
 
-    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name }, { name: project2.name }]) }
+    it { expect(serialized[:linked][:projects]).to eq([{ name: project1.name, links: {} }, { name: project2.name, links: {} }]) }
   end
 
   context 'has_many include' do
@@ -81,7 +81,7 @@ describe Encore::Serializer do
 
     let(:include) { 'users' }
 
-    it { expect(serialized[:linked][:users]).to eq([{ name: 'Allan' }, { name: 'Doe' }, { name: 'Ding' }, { name: 'Bob' }]) }
+    it { expect(serialized[:linked][:users]).to eq([{ name: 'Allan', links: {} }, { name: 'Doe', links: {} }, { name: 'Ding', links: {} }, { name: 'Bob', links: {} }]) }
   end
 
   context 'has_one include' do
@@ -98,6 +98,6 @@ describe Encore::Serializer do
 
     let(:include) { 'user' }
 
-    it { expect(serialized[:linked][:users]).to eq([{ name: 'Allan' }, { name: 'Doe' }]) }
+    it { expect(serialized[:linked][:users]).to eq([{ name: 'Allan', links: {} }, { name: 'Doe', links: {} }]) }
   end
 end

--- a/spec/encore/serializer/main_resource_spec.rb
+++ b/spec/encore/serializer/main_resource_spec.rb
@@ -33,5 +33,5 @@ describe Encore::Serializer do
   end
 
   it { expect(serialized[:users].count).to eq(2) }
-  it { expect(serialized[:users]).to eq([{ name: 'Allan' }, { name: 'Doe' }]) }
+  it { expect(serialized[:users]).to eq([{ name: 'Allan', links: {} }, { name: 'Doe', links: {} }]) }
 end


### PR DESCRIPTION
I think that we shouldn't have to add `attributes :links` in all of our `serializers`. This should be handled by Encore.

Thoughts?
