### PR TITLE
Revert feature to auto include collection association on has many macro

### DIFF
--- a/lib/encore/serializer/linked_resource_manager.rb
+++ b/lib/encore/serializer/linked_resource_manager.rb
@@ -8,7 +8,6 @@ module Encore
       def self.add(linked_ids, object)
         included_models = linked_ids.keys.map { |key| key.downcase }
         included_models << object.klass.name.downcase
-        included_models << object.klass.name.downcase.pluralize
 
         linked_ids.reduce({}) do |memo, (model, ids)|
           klass = model.constantize

--- a/spec/encore/serializer/linked/links_includes/links_includes_has_many_spec.rb
+++ b/spec/encore/serializer/linked/links_includes/links_includes_has_many_spec.rb
@@ -77,8 +77,8 @@ describe Encore::Serializer do
   end
 
   context 'already included resource' do
-    it { expect(serialized[:linked][:projects][0][:links][:users]).to eq([user1.id.to_s]) }
-    it { expect(serialized[:linked][:projects][1][:links][:users]).to eq([user2.id.to_s]) }
+    it { expect(serialized[:linked][:projects][0][:links][:users]).to eq({ href: '/users?project_id=1', type: 'users' }) }
+    it { expect(serialized[:linked][:projects][1][:links][:users]).to eq({ href: '/users?project_id=2', type: 'users' }) }
   end
 
   context 'not included resource' do


### PR DESCRIPTION
Only `belongs_to` and `has_one` are auto-included in the `linked` resources.

As we saw in the `Ember-Encore` adapter, it makes more sense this way.
