### PR TITLE
Add clean way to specify serializer options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ class PostSerializer < Encore::Serializer::Base
   # By default, root_key will be the pluralized model
   # name. If you want to set a custom root_key, you can
   # do that:
-  def self.root_key
-    :blog_posts
-  end
+  root_key :blog_posts
 end
 ```
 
@@ -118,9 +116,7 @@ Since we don’t want all associations to be exposed, we also need to allow the 
 class PostSerializer < Encore::Serializer::Base
   # ...
 
-  def self.can_include
-    [:author, :comments]
-  end
+  can_include :author, :comments
 end
 ```
 
@@ -167,9 +163,7 @@ If you want the `comments` to **always** be included when you request a `post`, 
 class PostSerializer < Encore::Serializer::Base
   # ...
 
-  def self.always_include
-    [:comments]
-  end
+  always_include :comments
 end
 ```
 

--- a/lib/encore/serializer/base.rb
+++ b/lib/encore/serializer/base.rb
@@ -23,27 +23,47 @@ module Encore
       end
 
       # Specify which resources the API can be included in the "linked" top-level key.
-      def self.can_include
-        []
+      def self.can_include(*value)
+        if value.any?
+          @can_include = value.flatten
+        else
+          @can_include ||= []
+        end
       end
 
       # Specify which resources the API always include in the "linked" top-level key.
-      def self.always_include
-        []
+      def self.always_include(*value)
+        if value.any?
+          @always_include = value.flatten
+        else
+          @always_include ||= []
+        end
       end
 
       # Specify which resources the API exposes URL to.
       # Default is can_include + always_include.
-      def self.can_access
-        can_include | always_include
+      def self.can_access(*value)
+        if value.any?
+          @can_access = value.flatten
+        else
+          @can_access ||= can_include | always_include
+        end
       end
 
-      def self.root_key
-        model_class.name.pluralize.underscore.to_sym
+      def self.root_key(value = nil)
+        if value
+          @root_key = value
+        else
+          @root_key ||= model_class.name.pluralize.underscore.to_sym
+        end
       end
 
-      def self.key_mappings
-        {}
+      def self.key_mappings(value = nil)
+        if value
+          @key_mappings = value
+        else
+          @key_mappings ||= {}
+        end
       end
     end
   end

--- a/spec/encore/persister/key_mappings_spec.rb
+++ b/spec/encore/persister/key_mappings_spec.rb
@@ -22,9 +22,7 @@ describe Encore::Persister do
         :name
       end
 
-      def key_mappings
-        { snake_case_key: :name }
-      end
+      key_mappings snake_case_key: :name
     end
   end
 

--- a/spec/encore/serializer/linked/always_include_resources_spec.rb
+++ b/spec/encore/serializer/linked/always_include_resources_spec.rb
@@ -58,9 +58,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name
 
-        def always_include
-          %i(project)
-        end
+        always_include :project
       end
     end
 
@@ -74,9 +72,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name
 
-        def always_include
-          %i(project)
-        end
+        always_include :project
       end
     end
 

--- a/spec/encore/serializer/linked/can_include_resources_spec.rb
+++ b/spec/encore/serializer/linked/can_include_resources_spec.rb
@@ -58,9 +58,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name
 
-        def can_include
-          %i(project)
-        end
+        can_include :project
       end
     end
 

--- a/spec/encore/serializer/linked/linked_resources_spec.rb
+++ b/spec/encore/serializer/linked/linked_resources_spec.rb
@@ -26,16 +26,12 @@ describe Encore::Serializer do
     spawn_serializer('ProjectSerializer') do
       attributes :name
 
-      def can_include
-        %i(user users)
-      end
+      can_include :user, :users
     end
     spawn_serializer('UserSerializer') do
       attributes :name
 
-      def can_include
-        %i(project)
-      end
+      can_include :project
     end
   end
 

--- a/spec/encore/serializer/linked/links_includes/links_includes_has_many_spec.rb
+++ b/spec/encore/serializer/linked/links_includes/links_includes_has_many_spec.rb
@@ -33,23 +33,17 @@ describe Encore::Serializer do
     spawn_serializer('ProjectSerializer') do
       attributes :name
 
-      def can_include
-        %i(organization user users)
-      end
+      can_include :organization, :user, :users
     end
     spawn_serializer('UserSerializer') do
       attributes :name
 
-      def can_include
-        %i(project)
-      end
+      can_include :project
     end
     spawn_serializer('OrganizationSerializer') do
       attributes :name
 
-      def can_include
-        %i(projects)
-      end
+      can_include :projects
     end
   end
 

--- a/spec/encore/serializer/linked/links_includes/links_includes_has_one_spec.rb
+++ b/spec/encore/serializer/linked/links_includes/links_includes_has_one_spec.rb
@@ -33,23 +33,17 @@ describe Encore::Serializer do
     spawn_serializer('ProjectSerializer') do
       attributes :name
 
-      def can_include
-        %i(organization user users)
-      end
+      can_include :organization, :user, :users
     end
     spawn_serializer('UserSerializer') do
       attributes :name
 
-      def can_include
-        %i(project)
-      end
+      can_include :project
     end
     spawn_serializer('OrganizationSerializer') do
       attributes :name
 
-      def can_include
-        %i(projects)
-      end
+      can_include :projects
     end
   end
 

--- a/spec/encore/serializer/links_resource_spec.rb
+++ b/spec/encore/serializer/links_resource_spec.rb
@@ -34,9 +34,7 @@ describe Encore::Serializer do
         spawn_serializer('UserSerializer') do
           attributes :name, :links
 
-          def can_include
-            %i(project)
-          end
+          can_include :project
         end
         spawn_model('Project') do
           has_many :users
@@ -64,9 +62,7 @@ describe Encore::Serializer do
         spawn_serializer('UserSerializer') do
           attributes :name, :links
 
-          def can_include
-            %i(project)
-          end
+          can_include :project
         end
         spawn_model('Project') do
           has_many :users
@@ -94,13 +90,9 @@ describe Encore::Serializer do
         spawn_serializer('UserSerializer') do
           attributes :name, :links
 
-          def can_include
-            %i(project)
-          end
+          can_include :project
 
-          def can_access
-            []
-          end
+          can_access []
         end
         spawn_model('Project') do
           has_many :users
@@ -128,13 +120,9 @@ describe Encore::Serializer do
         spawn_serializer('UserSerializer') do
           attributes :name, :links
 
-          def can_include
-            %i(project)
-          end
+          can_include :project
 
-          def can_access
-            []
-          end
+          can_access []
         end
         spawn_model('Project') do
           has_many :users
@@ -162,9 +150,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name, :links
 
-        def can_include
-          %i(project)
-        end
+        can_include :project
       end
       spawn_model('Project') do
         has_many :users
@@ -208,9 +194,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name, :links
 
-        def can_include
-          %i(projects)
-        end
+        can_include :projects
       end
       spawn_model('Project') do
         belongs_to :user
@@ -255,9 +239,7 @@ describe Encore::Serializer do
       spawn_serializer('UserSerializer') do
         attributes :name, :links
 
-        def can_include
-          %i(project)
-        end
+        can_include :project
       end
       spawn_model('Project')
       spawn_serializer('ProjectSerializer') do


### PR DESCRIPTION
Instead of writing this:

``` ruby
class PostSerializer < Encore::Serializer::Base
  def self.can_include
    [:project, :user]
  end

  def self.can_access
    [:project]
  end

  def self.root_key
    :user_posts
  end
end
```

We can now do this:

``` ruby
class PostSerializer < Encore::Serializer::Base
  can_include :project, :user
  can_access :project
  root_key :user_posts
end
```
