### PR TITLE
Replace downcase with underscore when generating urls for links payload

### DIFF
--- a/lib/encore/serializer/links_reflection_includer.rb
+++ b/lib/encore/serializer/links_reflection_includer.rb
@@ -20,7 +20,7 @@ module Encore
           reflection_type = reflection.name.to_s.pluralize
 
           {
-            href: "/#{reflection_type}?#{object.class.name.downcase}_id=#{object.id}",
+            href: "/#{reflection_type}?#{object.class.name.underscore}_id=#{object.id}",
             type: reflection_type
           }
         end
@@ -29,7 +29,7 @@ module Encore
           reflection_type = reflection.name.to_s
 
           {
-            href: "/#{object.class.name.downcase.pluralize}/#{object.id}/#{reflection_type}",
+            href: "/#{object.class.name.underscore.pluralize}/#{object.id}/#{reflection_type}",
             type: reflection_type.pluralize
           }
         end

--- a/spec/encore/serializer/links_resource_spec.rb
+++ b/spec/encore/serializer/links_resource_spec.rb
@@ -10,9 +10,14 @@ describe Encore::Serializer do
       create_table(:users, force: true) do |t|
         t.string :name, default: nil
         t.integer :project_id
+        t.integer :event_result_id
       end
       create_table(:projects, force: true) do |t|
         t.string :name, default: nil
+        t.integer :user_id
+      end
+      create_table(:event_results, force: true) do |t|
+        t.string :score, default: nil
         t.integer :user_id
       end
     end
@@ -184,6 +189,81 @@ describe Encore::Serializer do
 
       it { expect(serialized[:users][0][:links][:project]).to eq(expected_project) }
     end
+  end
+
+  context 'underscore route name' do
+    let(:spawn_objects!) do
+      spawn_model('User') do
+        has_many :event_results
+      end
+      spawn_serializer('UserSerializer') do
+        attributes :name, :links
+
+        def can_include
+          %i(event_results)
+        end
+      end
+      spawn_model('EventResult') do
+        belongs_to :user
+      end
+      spawn_serializer('EventResultSerializer') do
+        attributes :score
+      end
+    end
+
+    let(:create_records!) do
+      User.create name: 'Allan'
+      User.create name: 'Doe'
+      EventResult.create score: 'p1', user_id: 1
+      EventResult.create score: 'p2', user_id: 1
+    end
+
+    let(:include) { '' }
+    let(:expected_event_results) do
+      {
+        href: '/event_results?user_id=1',
+        type: 'event_results'
+      }
+    end
+
+    it { expect(serialized[:users][0][:links][:event_results]).to eq(expected_event_results) }
+  end
+
+  context 'underscore id' do
+    let(:spawn_objects!) do
+      spawn_model('User')
+      spawn_serializer('UserSerializer') do
+        attributes :name, :links
+      end
+      spawn_model('EventResult') do
+        has_many :users
+      end
+      spawn_serializer('EventResultSerializer') do
+        attributes :score
+
+        def can_include
+          %i(users)
+        end
+      end
+    end
+
+    let(:create_records!) do
+      EventResult.create score: 'p1'
+      EventResult.create score: 'p2'
+      User.create name: 'Allan', event_result_id: 1
+      User.create name: 'Doe', event_result_id: 1
+    end
+
+    let(:objects) { EventResult.all }
+    let(:include) { '' }
+    let(:expected_users) do
+      {
+        href: '/users?event_result_id=1',
+        type: 'users'
+      }
+    end
+
+    it { expect(serialized[:event_results][0][:links][:users]).to eq(expected_users) }
   end
 
   context 'has_many' do


### PR DESCRIPTION
- `rules?inputdevice_id=12` is now corrected to `rules?input_device_id=12`.
- `inputdevices/12/rule` is now corrected to `input_devices/12/rule`.
