### PR TITLE
Fix empty belongs to links generation to be nil

### DIFF
--- a/lib/encore/serializer/links_reflection_includer.rb
+++ b/lib/encore/serializer/links_reflection_includer.rb
@@ -38,6 +38,8 @@ module Encore
           reflection_type = reflection.name.to_s.pluralize
           reflection_id = object.send(reflection.foreign_key).try(:to_s)
 
+          return nil if reflection_id.blank?
+
           {
             href: "/#{reflection_type}/#{reflection_id}",
             id: reflection_id,

--- a/spec/encore/serializer/links_resource_spec.rb
+++ b/spec/encore/serializer/links_resource_spec.rb
@@ -168,6 +168,7 @@ describe Encore::Serializer do
     let(:create_records!) do
       User.create name: 'Allan', project_id: 1
       User.create name: 'Doe', project_id: 2
+      User.create name: 'Bar', project_id: nil
     end
 
     context 'not included' do
@@ -181,6 +182,15 @@ describe Encore::Serializer do
       end
 
       it { expect(serialized[:users][0][:links][:project]).to eq(expected_project) }
+    end
+
+    context 'empty association' do
+      let(:include) { '' }
+      let(:expected_project) do
+        nil
+      end
+
+      it { expect(serialized[:users][2][:links][:project]).to eq(expected_project) }
     end
 
     context 'included' do


### PR DESCRIPTION
Was: 
![image](https://cloud.githubusercontent.com/assets/464900/3249149/e3c7aa06-f195-11e3-89af-b9c6040f29dd.png)

Now: 
![image](https://cloud.githubusercontent.com/assets/464900/3249150/e858e648-f195-11e3-9b96-002e1e7fc7c2.png)
