### PR TITLE
Add support for Rails 4.1.4 dropping “reflections”

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ rvm:
 
 gemfile:
   - gemfiles/Gemfile.activerecord-4.0
-  - gemfiles/Gemfile.activerecord-4.1
+  - gemfiles/Gemfile.activerecord-4.1.3
+  - gemfiles/Gemfile.activerecord-4.1.4
 
 script:
   - 'echo "Checking code style" && bundle exec phare'

--- a/gemfiles/Gemfile.activerecord-4.1.3
+++ b/gemfiles/Gemfile.activerecord-4.1.3
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '../'
 
-gem 'activerecord', '~> 4.1.0'
+gem 'activerecord', '4.1.3'

--- a/gemfiles/Gemfile.activerecord-4.1.4
+++ b/gemfiles/Gemfile.activerecord-4.1.4
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '../'
+
+gem 'activerecord', '~> 4.1.4'

--- a/lib/encore/persister/links_parser.rb
+++ b/lib/encore/persister/links_parser.rb
@@ -7,7 +7,8 @@ module Encore
         links = args.delete(:links) || []
 
         links.each do |link, value|
-          reflection = @model.reflections[link.to_sym]
+          reflections = @model.try(:_reflections) || @model.reflections
+          reflection = reflections[link.to_sym]
           key = fetch_key(reflection)
           value = fetch_value(value, reflection)
 

--- a/lib/encore/serializer/base.rb
+++ b/lib/encore/serializer/base.rb
@@ -10,7 +10,8 @@ module Encore
       end
 
       def links
-        object.reflections.each_with_object({}) do |(_, reflection), memo|
+        reflections = object.try(:_reflections) || object.reflections
+        reflections.each_with_object({}) do |(_, reflection), memo|
           if object.association(reflection.name).loaded?
             fetcher = LinksReflectionIncluder::Loaded
           else

--- a/lib/encore/serializer/instance.rb
+++ b/lib/encore/serializer/instance.rb
@@ -34,7 +34,9 @@ module Encore
     private
 
       def reflections
-        @reflections ||= @collection.klass.reflections
+        @reflections ||= begin
+          @collection.klass.try(:_reflections) || @collection.klass.reflections
+        end
       end
 
       def serializer

--- a/lib/encore/serializer/linked_resource_manager.rb
+++ b/lib/encore/serializer/linked_resource_manager.rb
@@ -14,7 +14,8 @@ module Encore
           serializer = Utils.fetch_serializer(klass)
 
           collection = klass.where(id: ids.to_a)
-          available_includes = klass.reflections.map do |key, _|
+          reflections = klass.try(:_reflections) || klass.reflections
+          available_includes = reflections.map do |key, _|
             next unless included_models.include?(key.to_s)
             key
           end.compact


### PR DESCRIPTION
Rails 4.1.4 drops the `reflections` method on `ActiveRecord` classes and records. We rely on this method so we need to use the `_reflections` instead.
