### PR TITLE
Modify error objects to be compliant with latest JSON API spec

### DIFF
--- a/lib/encore/persister/errors_parser.rb
+++ b/lib/encore/persister/errors_parser.rb
@@ -4,12 +4,11 @@ module Encore
       extend ActiveSupport::Concern
 
       def parse_errors(record, index)
-        record.errors.messages.map do |field, values|
-          {
-            field: field.to_s,
-            types: values,
-            path: "#{record.class.name.underscore}/#{index}/#{field}"
-          }
+        record.errors.messages.each_with_object([]) do |(field, values), memo|
+          data = { path: "#{record.class.name.underscore}/#{index}/#{field}" }
+          values.each do |value|
+            memo << data.merge(title: value)
+          end
         end
       end
     end

--- a/spec/encore/persister/errors_resources_spec.rb
+++ b/spec/encore/persister/errors_resources_spec.rb
@@ -29,27 +29,30 @@ describe Encore::Persister do
     }]
   end
 
-  let(:expected_error) do
-    {
-      field: 'name',
-      types: ['can\'t be blank', 'is too short (minimum is 2 characters)'],
-      path: 'user/0/name'
-    }
+  let(:expected_errors) do
+    [
+      {
+        path: 'user/0/name',
+        title: 'can\'t be blank'
+      },
+      {
+        path: 'user/0/name',
+        title: 'is too short (minimum is 2 characters)'
+      }
+    ]
   end
 
   context 'create' do
     let(:model) { User }
 
     it { expect { persist! }.to_not change { model.count } }
-    it { expect { persist! }.to change { persister.errors.count }.to(1) }
-    it { expect { persist! }.to change { persister.errors.first }.to(expected_error) }
+    it { expect { persist! }.to change { persister.errors }.to(expected_errors) }
   end
 
   context 'update' do
     let(:model) { User.create name: 'Robert' }
 
     it { expect { persist! }.to_not change { model.reload.name } }
-    it { expect { persist! }.to change { persister.errors.count }.to(1) }
-    it { expect { persist! }.to change { persister.errors.first }.to(expected_error) }
+    it { expect { persist! }.to change { persister.errors }.to(expected_errors) }
   end
 end


### PR DESCRIPTION
Error objects are now compliant with the latest JSON API [spec](http://jsonapi.org/format/#errors).